### PR TITLE
Update Amplitude to v2.1.0

### DIFF
--- a/lib/amplitude/index.js
+++ b/lib/amplitude/index.js
@@ -17,7 +17,7 @@ var umd = 'function' == typeof define && define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.0.3-min.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.1.0-min.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -29,6 +29,7 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('trackAllPages', false)
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
+  .option('trackUtmProperties', true)
   .tag('<script src="' + src + '">');
 
 /**
@@ -41,11 +42,13 @@ var Amplitude = module.exports = integration('Amplitude')
 
 Amplitude.prototype.initialize = function(page){
   // jscs:disable
-  (function(h,a){var f=h.amplitude||{};f._q=[];function e(i){f[i]=function(){f._q.push([i].concat(Array.prototype.slice.call(arguments,0)))}}var c=["init","logEvent","setUserId","setUserProperties","setVersionName","setDomain","setDeviceId","setGlobalUserProperties"];for(var d=0;d<c.length;d++){e(c[d])}h.amplitude=f})(window,document);
+  (function(e,t){var r=e.amplitude||{};r._q=[];function a(e){r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)))}}var i=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties"];for(var o=0;o<i.length;o++){a(i[o])}e.amplitude=r})(window,document);
   // jscs:enable
+
   this.setDomain(window.location.href);
-  window.amplitude.init(this.options.apiKey);
-  this.setUserProperties(window.location.search);
+  window.amplitude.init(this.options.apiKey, null, {
+    includeUtm: this.options.trackUtmProperties
+  });
 
   var self = this;
   if (umd) {
@@ -121,7 +124,15 @@ Amplitude.prototype.identify = function(identify){
 Amplitude.prototype.track = function(track){
   var props = track.properties();
   var event = track.event();
+  var revenue = track.revenue();
+
+  // track the event
   window.amplitude.logEvent(event, props);
+
+  // also track revenue
+  if (revenue) {
+    window.amplitude.logRevenue(revenue);
+  }
 };
 
 /**
@@ -143,19 +154,4 @@ Amplitude.prototype.setDomain = function(href){
 
 Amplitude.prototype.setDeviceId = function(deviceId){
   if (deviceId) window.amplitude.setDeviceId(deviceId);
-};
-
-/**
- * Set campaign params as global user properties
- *
- * @param {String} query
- */
-
-Amplitude.prototype.setUserProperties = function(query){
-  var campaign = utm(query);
-  // switch name to campaign so it doesn't conflict with the user's name
-  var campaignName = campaign.name;
-  campaign.campaign = campaignName;
-  delete campaign.name;
-  if (campaign) window.amplitude.setUserProperties(campaign);
 };

--- a/lib/amplitude/test.js
+++ b/lib/amplitude/test.js
@@ -33,6 +33,7 @@ describe('Amplitude', function(){
       .global('amplitude')
       .option('apiKey', '')
       .option('trackAllPages', false)
+      .option('trackUtmProperties', true)
       .option('trackNamedPages', true));
   });
 
@@ -93,23 +94,23 @@ describe('Amplitude', function(){
         });
       });
 
-      it('should set user properties', function(){
-        analytics.spy(amplitude, 'setUserProperties');
+      it('should initialize utm properties', function(){
+        amplitude.options.trackUtmProperties = true;
         analytics.initialize();
-        analytics.page();
-        analytics.called(amplitude.setUserProperties, window.location.search);
+        analytics.once('ready', function(){
+          analytics.spy(window.amplitude, '_initUtmData');
+          amplitude.initialize();
+          analytics.called(window.amplitude._initUtmData);
+        });
       });
 
-      describe('#setUserProperties', function(){
-        beforeEach(function(){
-          analytics.initialize();
-        });
-
-        it('should set campaign object as user property', function(){
-          var query = '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name';
-          analytics.spy(window.amplitude, 'setUserProperties');
-          amplitude.setUserProperties(query);
-          analytics.called(window.amplitude.setUserProperties, { source:'source', medium:'medium', term:'term', content:'content', campaign:'name' });
+      it('should not track utm properties if disabled', function(){
+        amplitude.options.trackUtmProperties = false;
+        analytics.initialize();
+        analytics.once('ready', function(){
+          analytics.spy(window.amplitude, '_initUtmData');
+          amplitude.initialize();
+          analytics.didNotCall(window.amplitude._initUtmData);
         });
       });
     });
@@ -193,16 +194,24 @@ describe('Amplitude', function(){
     describe('#track', function(){
       beforeEach(function(){
         analytics.stub(window.amplitude, 'logEvent');
+        analytics.stub(window.amplitude, 'logRevenue');
       });
 
       it('should send an event', function(){
         analytics.track('event');
         analytics.called(window.amplitude.logEvent, 'event');
+        analytics.didNotCall(window.amplitude.logRevenue);
       });
 
       it('should send an event and properties', function(){
         analytics.track('event', { property: true });
         analytics.called(window.amplitude.logEvent, 'event', { property: true });
+        analytics.didNotCall(window.amplitude.logRevenue);
+      });
+
+      it('should send a revenue event', function(){
+        analytics.track('event', { revenue: 19.99 });
+        analytics.called(window.amplitude.logRevenue, 19.99);
       });
     });
   });


### PR DESCRIPTION
- Adds mapping for logRevenue.
- Now uses Amplitude internal UTM tracking.

@curtisliu: This needs v2.1.0 to be release on the CDN before this can be sent as a PR to segment.
